### PR TITLE
manpages for ghostmirror :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 man/ghostmirror.1.gz
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 man/ghostmirror.1.gz
+man/ghostmirror.1
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+man/ghostmirror.1.gz

--- a/distro/PKGBUILD
+++ b/distro/PKGBUILD
@@ -3,7 +3,7 @@
 prj='ghostmirror'
 pkgname=($prj)
 pkgdesc='modern alternative to reflector, true check mirror status, mirror download speed and more.'
-pkgver='0.9.17'
+pkgver='0.9.18'
 pkgrel=1
 arch=('x86_64')
 url="https://github.com/vbextreme/${prj}.git"

--- a/man/gen-manpages.sh
+++ b/man/gen-manpages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+CWD="$(dirname "$0")"
+OUTPUT_FILE="${CWD}/ghostmirror.1"
+
+# read from environment if set otherwise use a default value
+CURRENT_VERSION="${CURRENT_VERSION:='0.9.18'}"
+CURRENT_DATE="$(date '+%d %b %Y')"
+
+# escape dots '.' became '\&.'
+CURRENT_VERSION="${CURRENT_VERSION//'.'/'\\\&.'}"
+
+# read .skel content
+CONTENT=$(< "${OUTPUT_FILE}.skel")
+
+# replace placeholders in ghostmirror.1.skel file
+sed -s 's/:CURRENT_DATE:/'"${CURRENT_DATE}"'/g;s/:CURRENT_VERSION:/'"${CURRENT_VERSION}"'/g' <<< "${CONTENT}" > "${OUTPUT_FILE}"

--- a/man/ghostmirror.1
+++ b/man/ghostmirror.1
@@ -188,4 +188,3 @@ No known bugs\&.
 .SH AUTHOR
 vbextreme - https://github\&.com/vbextreme/ghostmirror
 
-

--- a/man/ghostmirror.1
+++ b/man/ghostmirror.1
@@ -1,0 +1,191 @@
+.\" Manpage for ghostmirror\&.
+.\" Contact vbextreme to correct errors or typos\&.
+.TH man 1 "26 Dec 2024" "0\&.9\&.18" "ghostmirror man page"
+.SH NAME
+ghostmirror \- rank pacman mirrors
+.SH SYNOPSIS
+\fIghostmirror\fR [options] <values>
+.SH DESCRIPTION
+\fIghostmirror\fR compares mirror databases with the local database and provides a detailed report on the status of mirror packages. It identifies whether the mirrors are more or less up-to-date compared to the local database, displaying errors or the names of packages that are outdated\&. 
+
+Custom sorting mode allows generation of a prioritized mirror list tailored to user requirements\&.  For users who prefer automation, adding a single command-line argument enables automatic activation of the systemd service, managing
+mirrors without manual intervention\&. 
+
+
+
+.SH OPTIONS
+\fB\-a, \-\-arch\fR
+.RS 4
+select arch, default 'x86_64'
+.RE
+.PP
+\fB\-m, \-\-mirrorfile\fR
+.RS 4
+use mirror file instead of downloading mirrorlist, without -m and -u ghostmirror download mirrorlist and search in all mirror\&.
+you can use -m /etc/pacman\&.d/mirrorlist\&.pacnew if you not want downloading mirrorlist but used local list\&.
+.RE
+.PP
+\fB\-c, \-\-country\fR
+.RS 4
+select country from mirrorlist\&.
+if mirrorlist is not same the default mirrorlist and not have ##Country or mixed mirror, the selection country fail
+.RE
+.PP
+\fB\-C, \-\-country-list\fR
+.RS 4
+show all possibile country
+.RE
+.PP
+\fB\-u, \-\-uncommented\fR
+.RS 4
+use only uncommented mirror, by default use commented and uncommented mirror\&.
+with -m is simple to check local mirrolist -mu /etc/pacman\&.d/mirrorlist\&.
+.RE
+.PP
+\fB\-d, \-\-downloads\fR
+.RS 4
+set numbers of parallel download, default '4'\&.
+if you abuse the download is more simple to fail, 1,4,8,16 is good value, >16 you can try but is not very affidable
+.RE
+.PP
+\fB\-O, \-\-timeout\fR
+.RS 4
+set timeout in seconds for not reply mirror, default 5s
+.RE
+.PP
+\fB\-p, \-\-progress\fR
+.RS 4
+show progress, default false
+.RE
+.PP
+\fB\-P, \-\-progress-colors\fR
+.RS 4
+same -p but with -o add color table
+.RE
+.PP
+\fB\-o, \-\-output\fR
+.RS 4
+enable table output, with -P display with colors
+.RE
+.PP
+\fB\-s, \-\-speed\fR
+.RS 4
+test speed for downloading:
+light: download one small package ~6MiB
+normal: download light + normal package ~250Mib
+heavy: download light+normal+heavy packege ~350MiB, total download >500Mib
+.RE
+.PP
+\fB\-S, \-\-sort\fR
+.RS 4
+sort result for any of fields display in table, mutiple fields supported\&.
+country and mirror is sorted by name
+proxy first false, last true
+state first success last error
+outofdate, retry and ping, display first less value
+uptodate, morerecent, sync, speed and extimated, display first great value
+.RE
+.PP
+\fB\-l, \-\-list\fR
+.RS 4
+save new mirrorlist in file passed as argument\&.
+special name, stdout, can be used for write to stdout file\&.
+.RE
+.PP
+\fB\-L, \-\-max-list\fR
+.RS 4
+set max numbers of output mirrors
+.RE
+.PP
+\fB\-T, \-\-type\fR
+.RS 4
+select mirrors type, http,https,all
+.RE
+.PP
+\fB\-i, \-\-investigate\fR
+.RS 4
+search mirror errors to detect the problem\&.
+can select mode: error, outofdate, all\&.
+error: investigate only on error\&.
+outofdate: investigate only on outofdate package\&.
+all: same passing -i error,uptodate
+.RE
+.PP
+\fB\-D, \-\-systemd\fR
+.RS 4
+auto manager systemd\&.timer\&.
+when you pass this option the software activate login linger if not ebabled\&.
+auto create ghostmirror\&.service and ghostmirror\&.timer
+the config\&.service start ghostmirror in the same mode you haved executed it, with only differences that need -l\&.
+for exaples if you execute: -DmuldsS 16 light extimated,speed
+the service is always start with 16 parallel downloads, speed light and extimated,speed sort\&.
+for change you can simple repeat a command\&.
+the expire timer is the first element in table and is dinamic, can change every time\&.
+.RE
+.PP
+\fB\-t, \-\-time\fR
+.RS 4
+in systemd timer whend extimate date is ellapsed can set a time\&. Set specific hh:mm:ss when start service, default 00:00:00\&.
+validate input with systemd-analyzer calendar hh:mm:ss before use
+.RE
+.PP
+\fB\-f, \-\-fixed-time\fR
+.RS 4
+in systemd timer use fixed time instead of extimated time\&.
+validate input with systemd-analyzer calendar hh:mm:ss before use
+.RE
+.PP
+\fB\-h, \-\-help\fR
+display this help
+.RE
+.PP
+.RS 4
+.SH EXAMPLES
+
+in the first step you need to search a good quantity of mirrors\&.
+-P for get progress and output colors, -o for get output table\&.
+-c for select country, for example Italy,Germany,France
+-l where do you save list
+-L max numbers of output mirror in list
+-S sort mode, first add state, in this mode remove error mirror, after you can add outofdate, in this mode display first the mirror sync, can also add morerecent to ensure you never go out of sync, and at the end, you can add ping to try to prioritize the closest ones\&.
+.IP
+.nf
+\f[C]
+$ \fIghostmirror\fR -PoclLS Italy,Germany,France \&./mirrorlist\&.new 30 state,outofdate,morerecent,ping
+\f[R]
+.fi
+.PP
+
+
+Now, instead of taking the mirrors from the global list, we will better evaluate the mirrors found in the first step\&.
+While the first step will be performed only once or rarely, this step will be the one you repeat periodically\&.
+-P -o -l is same the previous step
+-m tell software to use a local mirror list, and -u for use only uncommented mirror
+-s for apply a real test for mirror speed
+-S change a sort mode, remove ping, add extimated for get more stable mirror and speed for reorder speed
+.IP
+.nf
+\f[C]
+$ \fIghostmirror\fR -PmuolsS  \&./mirrorlist\&.new \&./mirrorlist\&.new light state,outofdate,morerecent,extimated,speed
+\f[R]
+.fi
+.PP
+
+The following command analyzes mirrors for the selected country (Italy) using 16 threads, displays a progress bar, and sorts them based on the specified criteria (recent updates, outdated status, and speed) and print the result to the stdout
+.IP  
+.nf  
+\f[C]  
+$ \fIghostmirror\fR -Pc Italy -t 16 -s light -S morerecent,outofdate,speed  
+\f[R]  
+.fi  
+.PP  
+
+
+.SH SEE ALSO
+rankmirrors(8) reflector(1)
+.SH BUGS
+No known bugs\&.
+.SH AUTHOR
+vbextreme - https://github\&.com/vbextreme/ghostmirror
+
+

--- a/man/ghostmirror.1.skel
+++ b/man/ghostmirror.1.skel
@@ -1,6 +1,6 @@
 .\" Manpage for ghostmirror\&.
 .\" Contact vbextreme to correct errors or typos\&.
-.TH man 1 "26 Dec 2024" "0\&.9\&.18" "ghostmirror man page"
+.TH man 1 ":CURRENT_DATE:" ":CURRENT_VERSION:" "ghostmirror man page"
 .SH NAME
 ghostmirror \- rank pacman mirrors
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,11 @@ src += [ 'src/systemd.c' ]
 message('compressing manpages')
 run_command('gzip', '-kf', './man/ghostmirror.1', check: true)
 
+# thx chatgpt
+install_data('man/ghostmirror.1.gz',
+    install_dir: join_paths(get_option('datadir'), 'man', 'man1')
+)
+
 ##################
 # compiler flags #
 ##################
@@ -123,7 +128,7 @@ elif( get_option('optimize') == 1 )
   message('generic optimization enabled')
   add_global_arguments('-O2', language: 'c')
 else
-   add_global_arguments('-O0', language: 'c') 
+  add_global_arguments('-O0', language: 'c') 
   add_global_arguments('-g', language: 'c')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,11 @@ src += [ 'src/systemd.c' ]
 # man files #
 #############
 
+message('generating manpages')
+run_command('bash', './man/gen-manpages.sh', env: {
+    'CURRENT_VERSION': meson.project_version()
+})
+
 message('compressing manpages')
 run_command('gzip', '-kf', './man/ghostmirror.1', check: true)
 

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,9 @@ src += [ 'src/systemd.c' ]
 # man files #
 #############
 
+message('compressing manpages')
+run_command('gzip', '-kf', './man/ghostmirror.1', check: true)
+
 ##################
 # compiler flags #
 ##################

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,10 @@ if get_option('eveloper')
     message('update README')
     run_command('sed', '-i', '-r', '-e', 's/^' + meson.project_name() + '[ \\t]*v(.*)/' + meson.project_name() + ' v' + version['str'] + '/', './README.md', check: true)
     run_command('sed', '-i', '-r', '-e', '0,/^\* v.*/{s/\*(.*)/\* v' + version['str'] + ' ' + version['dsc'] + '\\n\*\\1/}' , './README.md', check: true).stdout().strip()
+    message('generating manpages')
+    run_command('bash', './man/gen-manpages.sh', env: {
+        'CURRENT_VERSION': version['str']
+    })
     message('update git')
     run_command('git', 'commit', '-a', '-m', version['dsc'], check: true)
     run_command('git', 'tag', '-a', 'v' + version['str'], '-m', version['dsc'], check: true)
@@ -66,18 +70,9 @@ src += [ 'src/systemd.c' ]
 # man files #
 #############
 
-message('generating manpages')
-run_command('bash', './man/gen-manpages.sh', env: {
-    'CURRENT_VERSION': meson.project_version()
-})
 
-message('compressing manpages')
-run_command('gzip', '-kf', './man/ghostmirror.1', check: true)
 
-# thx chatgpt
-install_data('man/ghostmirror.1.gz',
-    install_dir: join_paths(get_option('datadir'), 'man', 'man1')
-)
+install_man('man/ghostmirror.1')
 
 ##################
 # compiler flags #


### PR DESCRIPTION
Compared to the previous pull, I decided to write a bash script that automatically generates version and date of the manpage at build time. This is achieved through a system that includes a template (.skel) with some placeholders replaced by the proper value, the version is read by an environment variable exported by meson.build