### PR TITLE
Fix sorting by estimated

### DIFF
--- a/src/arch.c
+++ b/src/arch.c
@@ -27,7 +27,6 @@ __private const char* SORTNAME[] = {
 	"outofdate",
 	"uptodate",
 	"morerecent",
-	"retry",
 	"speed",
 	"ping",
 	"estimated"


### PR DESCRIPTION
When retry was removed from sort options, it wasn't removed from the `SORTNAME` array which caused the 'estimated' option to [have the wrong index](https://github.com/vbextreme/ghostmirror/blob/7e498cec56f9e1f144f6c3005e9b9d6c6bbe74ad/src/arch.c#L765) 